### PR TITLE
PHP 7 on Declaration of HtmlCacheBaseHelper::beforeRender() should be…

### DIFF
--- a/View/Helper/HtmlCacheBaseHelper.php
+++ b/View/Helper/HtmlCacheBaseHelper.php
@@ -112,7 +112,7 @@ class HtmlCacheBaseHelper extends AppHelper {
  * @return void
  * @access public
  */
-	public function beforeRender() {
+	public function beforeRender($viewFile) {
 		if($this->Session->read('Message')) {
 			$this->isFlash = true;
 		}
@@ -124,7 +124,7 @@ class HtmlCacheBaseHelper extends AppHelper {
  * @return void
  * @access public
  */
-	public function afterLayout() {
+	public function afterLayout($layoutFile) {
 		if(!$this->_isCachable()) {
 			return;
 		}


### PR DESCRIPTION
CakePHP 2.7.7 on PHP 7 run put below E_WARNINGs. This request is fixed.

… compatible with Helper::beforeRender($viewFile) and Declaration of HtmlCacheBaseHelper::afterLayout() should be compatible with Helper::afterLayout($layoutFile)
